### PR TITLE
#Task 72 - Made Drone Icon attached to Drone Objects

### DIFF
--- a/QmlMap.qml
+++ b/QmlMap.qml
@@ -74,7 +74,7 @@ Item
             model: ListModel { id: markersModel }
             delegate: MapQuickItem
             {
-                coordinate: QtPositioning.coordinate(latitude, longitude)
+                coordinate: QtPositioning.coordinate(model.latitude, model.longitude)
                 anchorPoint.x: markerImage.width / 2
                 anchorPoint.y: markerImage.height
                 sourceItem: Image {
@@ -106,4 +106,15 @@ Item
             }
         }
     }
+    Component.onCompleted: {
+            let drones = mapController.getAllDrones();
+            markersModel.clear();
+            for (let i = 0; i < drones.length; i++) {
+                markersModel.append({
+                    "name": drones[i].name,
+                    "latitude": drones[i].latitude,
+                    "longitude": drones[i].longitude
+                });
+            }
+        }
 }

--- a/droneclass.cpp
+++ b/droneclass.cpp
@@ -80,7 +80,7 @@ void DroneClass::setLattitude(const double lat) {
 //temporary
 void DroneClass::setLongitude(const double longitude) {
     if (m_longitude != longitude) {
-        m_lattitude = longitude;
+        m_longitude = longitude;
         emit longitudeChanged();
     }
 }

--- a/mapcontroller.cpp
+++ b/mapcontroller.cpp
@@ -1,4 +1,5 @@
 #include "mapcontroller.h"
+#include <QDebug>
 
 /*
  * Used to emit signals to our QML functions.
@@ -9,7 +10,68 @@
 // Define constructor for MapController class
 MapController::MapController(QObject *parent)
     // Defines all variables within our map
-    : QObject(parent), m_currentMapType(0), m_supportedMapTypesCount(3) {}
+    : QObject(parent), m_currentMapType(0), m_supportedMapTypesCount(3)
+{
+
+    // Populate with dummy drone objects for testing icon markers using setLattitude and setLongitude
+    DroneClass* drone1 = new DroneClass(this);
+    drone1->setName("Drone 1");
+    drone1->setLattitude(34.059174611493965);
+    drone1->setLongitude(-117.82051240067321);
+    addDrone(drone1);
+
+    DroneClass* drone2 = new DroneClass(this);
+    drone2->setName("Drone 2");
+    drone2->setLattitude(34.0600);
+    drone2->setLongitude(-117.8210);
+    addDrone(drone2);
+
+    DroneClass* drone3 = new DroneClass(this);
+    drone3->setName("Drone 3");
+    drone3->setLattitude(34.0615);
+    drone3->setLongitude(-117.8225);
+    addDrone(drone3);
+
+    DroneClass* drone4 = new DroneClass(this);
+    drone4->setName("Drone 4");
+    drone4->setLattitude(37.7749);
+    drone4->setLongitude(-122.4194);
+    addDrone(drone4);
+
+    DroneClass* drone5 = new DroneClass(this);
+    drone5->setName("Drone 5");
+    drone5->setLattitude(34.0119);
+    drone5->setLongitude(-118.4916);
+    addDrone(drone5);
+}
+
+void MapController::addDrone(DroneClass* drone)
+{
+    if (drone) {
+        m_drones.append(drone);
+    }
+}
+
+QVariantList MapController::getAllDrones() const
+{
+    QVariantList droneList;
+    for (const DroneClass* drone : m_drones) {
+        QVariantMap droneData;
+        droneData["name"] = drone->getName();
+        droneData["latitude"] = drone->getLattitude();
+        droneData["longitude"] = drone->getLongitude();
+        droneList.append(droneData);
+    }
+    return droneList;
+}
+
+void MapController::createDrone(const QString &input_name){
+    DroneClass* temp = new DroneClass(this);
+    temp->setName(input_name);
+    temp->setLattitude(34.06152);
+    temp->setLongitude(-117.82254);
+    addDrone(temp);
+}
 
 void MapController::setCenterPosition(const QVariant &lat, const QVariant &lon)
 {
@@ -52,3 +114,14 @@ void MapController::addMarker(const QPair<double, double> &position)
     m_markers.append(position);
     emit locationMarked(QVariant(position.first), QVariant(position.second));
 }
+
+//Prints all Dummy Drone Objects
+// void MapController::debugPrintDrones() const {
+//     qDebug() << "------ Drone Objects ------";
+//     for (const DroneClass* drone : m_drones) {
+//         qDebug() << "Drone Name:" << drone->getName()
+//         << ", Latitude:" << drone->getLattitude()
+//         << ", Longitude:" << drone->getLongitude();
+//     }
+//     qDebug() << "---------------------------";
+// }

--- a/mapcontroller.h
+++ b/mapcontroller.h
@@ -5,6 +5,7 @@
 #include <QVariant>
 #include <QPair>
 #include <QVector>
+#include "droneclass.h"
 
 /*
  * Qt uses Slots and Signals to create responsive UI/GUI applications.
@@ -25,12 +26,17 @@ class MapController : public QObject
 
 public:
     explicit MapController(QObject *parent = nullptr);
+    // Q_INVOKABLE void debugPrintDrones() const;
+    Q_INVOKABLE void createDrone(const QString &input_name);
+
 
 public slots:
     void setCenterPosition(const QVariant &lat, const QVariant &lon);
     void setLocationMarking(const QVariant &lat, const QVariant &lon);
     void changeMapType(int typeIndex);
 
+    Q_INVOKABLE void addDrone(DroneClass* drone);
+    Q_INVOKABLE QVariantList getAllDrones() const;
 signals:
     void centerPositionChanged(const QVariant &lat, const QVariant &lon);
     void locationMarked(const QVariant &lat, const QVariant &lon);
@@ -41,6 +47,8 @@ private:
     QVector<QPair<double, double>> m_markers;
     int m_currentMapType;
     int m_supportedMapTypesCount;
+
+    QVector<DroneClass*> m_drones;
 
     void updateCenter(const QPair<double, double> &center);
     void addMarker(const QPair<double, double> &position);


### PR DESCRIPTION
Summary

- Created dummy drone data by adding dummy drone objects in the MapController constructor using setLattitude and setLongitude methods, ensuring each drone has distinct coordinate data.

- Fixed setLongitude bug in DroneClass::setLongitude 

- Added getAllDrones() Function in MapController
  
- Updated QmlMap.qml to Dynamically Populate Drone Markers

- Tested and runs well. 
<img width="952" alt="GCS - #Task 72" src="https://github.com/user-attachments/assets/8633d6a2-24f9-4d99-af7c-d2e387756d2f" />

