### PR TITLE
Moved menu bar from window border to inside UI

### DIFF
--- a/DroneMenuBar.qml
+++ b/DroneMenuBar.qml
@@ -1,0 +1,526 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Qt.labs.platform
+import "qrc:/gcsStyle" as GcsStyle
+
+/*
+ * DroneMenuBar - Menu bar component to display various features and actions
+ * Located at the top of the drone tracking panel
+ * Contains two dropdown items:
+ * 1. "GCS" that opens the manage drone window.
+ * 2. "Command Menu" that shows a submenu with the 4 command options.
+ */
+
+Rectangle {
+    id: menuBar
+    height: 40
+    color: "transparent"
+    // Colors sourced from theme
+    property color baseColor: GcsStyle.PanelStyle.primaryColor
+    property color borderClr: GcsStyle.PanelStyle.buttonBorderColor
+    property color hoverClr: GcsStyle.PanelStyle.buttonHoverColor
+    property color pressedClr: GcsStyle.PanelStyle.buttonPressedColor
+
+    Row {
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.margins: 0
+        spacing: 15
+
+        // "GCS" Menu Button 
+        Rectangle {
+            id: gcsMenuButton
+            height: 35
+            width: 90
+            radius: 15 // Gives rounded edges
+            // Button color state logic for hovering/pressing
+            color: pressed ? pressedClr :
+                   hovered ? hoverClr :
+                   baseColor
+            border.color: borderClr
+            border.width: 1
+
+            // Text styling
+            Text {
+                text: "GCS ▼"
+                anchors.centerIn: parent
+                color: GcsStyle.PanelStyle.textPrimaryColor
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                font.pointSize: 10
+            }
+
+            // Tracks button's normal state (not being interacted with)
+            property bool hovered: false
+            property bool pressed: false
+
+            // Mouse event states 
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                acceptedButtons: Qt.LeftButton
+                onClicked: gcsMenu.open()
+                onPressed: gcsMenuButton.pressed = true
+                onReleased: gcsMenuButton.pressed = false
+                onCanceled: gcsMenuButton.pressed = false
+                onEntered: gcsMenuButton.hovered = true
+                onExited: gcsMenuButton.hovered = false
+            }
+
+            // Shadow effect
+            Rectangle {
+                x: gcsMenuButton.x + 2
+                y: gcsMenuButton.y + 2
+                width: gcsMenuButton.width
+                height: gcsMenuButton.height
+                color: "#30000000"
+                radius: gcsMenuButton.radius
+                z: -1
+            }
+        }
+
+        // Command Menu Button
+        Rectangle {
+            id: commandMenuButton
+            height: 35
+            width: 135
+            radius: 15 // Gives rounded edges
+            // Button color state logic for hovering/pressing
+            color: pressed ? pressedClr :
+                   hovered ? hoverClr :
+                   baseColor
+            border.color: borderClr
+            border.width: 1
+
+            // Text styling
+            Text {
+                text: "Command Menu ▼"
+                anchors.centerIn: parent
+                color: GcsStyle.PanelStyle.textPrimaryColor
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                font.pointSize: 10
+            }
+
+            // Tracks button default state (not hovered/pressed)
+            property bool hovered: false
+            property bool pressed: false
+
+            // Mouse states to make rounded hover/press visuals
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                acceptedButtons: Qt.LeftButton
+                onClicked: commandMenu.open()
+                onPressed: commandMenuButton.pressed = true
+                onReleased: commandMenuButton.pressed = false
+                onCanceled: commandMenuButton.pressed = false
+                onEntered: commandMenuButton.hovered = true
+                onExited: commandMenuButton.hovered = false
+            }
+
+            // Shadow effect
+            Rectangle {
+                anchors.fill: parent
+                anchors.leftMargin: 2
+                anchors.topMargin: 2
+                anchors.rightMargin: -2
+                anchors.bottomMargin: -2
+                color: "#30000000"
+                radius: parent.radius
+                z: -1
+            }
+        }
+    }
+
+    // Keyboard shortcut for Command Menu (Ctrl+Shift+P on Windows, Cmd+Shift+P on Mac)
+    Shortcut {
+        sequence: "Ctrl+Shift+P"
+        onActivated: commandMenu.open()
+    }
+
+    // ESC key to close any open menu
+    Shortcut {
+        sequence: "Escape"
+        onActivated: {
+            if (gcsMenu.visible) gcsMenu.close()
+            if (commandMenu.visible) commandMenu.close()
+        }
+    }
+
+    // GCS Menu Popup
+    Popup {
+        id: gcsMenu
+        x: gcsMenuButton.x + 2
+        // positioned just below the menu button
+        y: menuBar.height + 5
+        width: 200
+        height: 50
+        modal: false
+        // Allows popup to receive keyboard events
+        focus: true
+        // Closes popup when clicking outside
+        closePolicy: Popup.CloseOnPressOutside
+
+        background: Rectangle {
+            color: GcsStyle.PanelStyle.primaryColor
+            border.color: GcsStyle.PanelStyle.buttonBorderColor
+            border.width: 1
+            radius: 4
+        }
+
+        // Column layout for menu items
+        Column {
+            anchors.fill: parent
+            anchors.margins: 5
+            spacing: 2
+
+            Button {
+                width: parent.width
+                height: 30
+                text: "Manage Drones"
+
+                background: Rectangle {
+                    // Button background color logic for hovering and clicking, for intuity
+                    color: parent.pressed ? GcsStyle.PanelStyle.buttonPressedColor :
+                           parent.hovered ? GcsStyle.PanelStyle.buttonHoverColor :
+                           "transparent"
+                    radius: 2
+                }
+
+                // Text styling
+                contentItem: Text {
+                    text: parent.text
+                    color: GcsStyle.PanelStyle.textPrimaryColor
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 11
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                }
+
+
+                onClicked: {
+                    gcsMenu.close()
+                    var component = Qt.createComponent("manageDroneWindow.qml")
+                    if (component.status === Component.Ready) {
+                        var window = component.createObject(null)
+                        if (window !== null) {
+                            window.show()
+                        } else {
+                            console.error("Error creating object:", component.errorString());
+                        }
+                    } else {
+                        console.error("Component not ready:", component.errorString());
+                    }
+                }
+            }
+        }
+    }
+
+    // Command Menu Popup
+    Popup {
+        id: commandMenu
+        x: commandMenuButton.x + 2
+        y: menuBar.height + 5
+        width: 200
+        height: 200
+        modal: false
+        // Allows popup to receive keyboard events
+        focus: true
+        // Closes popup when clicking outside
+        closePolicy: Popup.CloseOnPressOutside
+
+        background: Rectangle {
+            color: GcsStyle.PanelStyle.primaryColor
+            border.color: GcsStyle.PanelStyle.buttonBorderColor
+            border.width: 1
+            radius: 4
+        }
+
+        // Column layout for menu items
+        Column {
+            anchors.fill: parent
+            anchors.margins: 5
+            spacing: 2
+
+            // ARM Menu item
+            Button {
+                width: parent.width
+                height: 30
+                text: "ARM"
+
+                background: Rectangle {
+                    // Background color logic for clicking and hovering
+                    color: parent.pressed ? GcsStyle.PanelStyle.buttonPressedColor :
+                           parent.hovered ? GcsStyle.PanelStyle.buttonHoverColor :
+                           "transparent"
+                    radius: 2
+                }
+
+                // Menu Item text styling
+                contentItem: Text {
+                    text: parent.text
+                    color: GcsStyle.PanelStyle.textPrimaryColor
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 11
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                }
+
+                onClicked: {
+                    commandMenu.close()
+                    var component = Qt.createComponent("armWindow.qml")
+                    if (component.status === Component.Ready) {
+                        var window = component.createObject(null)
+                        if (window !== null) {
+                            window.show()
+                        } else {
+                            console.error("Error creating ARM window:", component.errorString())
+                        }
+                    } else {
+                        console.error("Component not ready:", component.errorString())
+                    }
+                }
+            }
+
+            // Take-off Menu item
+            Button {
+                width: parent.width
+                height: 30
+                text: "Take-off"
+
+                background: Rectangle {
+                    // Button background color logic
+                    color: parent.pressed ? GcsStyle.PanelStyle.buttonPressedColor :
+                           parent.hovered ? GcsStyle.PanelStyle.buttonHoverColor :
+                           "transparent"
+                    radius: 2
+                }
+
+                // Text styling
+                contentItem: Text {
+                    text: parent.text
+                    color: GcsStyle.PanelStyle.textPrimaryColor
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 11
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                }
+
+                onClicked: {
+                    commandMenu.close()
+                    var component = Qt.createComponent("takeOffWindow.qml")
+                    if (component.status === Component.Ready) {
+                        var window = component.createObject(null)
+                        if (window !== null) {
+                            window.show()
+                        } else {
+                            console.error("Error creating Take-off window:", component.errorString())
+                        }
+                    } else {
+                        console.error("Component not ready:", component.errorString())
+                    }
+                }
+            }
+
+            // Coordinate Navigation Menu item
+            Button {
+                width: parent.width
+                height: 30
+                text: "Coordinate Navigation"
+
+                background: Rectangle {
+                    // Background color logic
+                    color: parent.pressed ? GcsStyle.PanelStyle.buttonPressedColor :
+                           parent.hovered ? GcsStyle.PanelStyle.buttonHoverColor :
+                           "transparent"
+                    radius: 2
+                }
+
+                // Text styling
+                contentItem: Text {
+                    text: parent.text
+                    color: GcsStyle.PanelStyle.textPrimaryColor
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 11
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                }
+
+                onClicked: {
+                    commandMenu.close()
+                    var component = Qt.createComponent("coordinateNavigationWindow.qml")
+                    if (component.status === Component.Ready) {
+                        var window = component.createObject(null)
+                        if (window !== null) {
+                            window.show()
+                        } else {
+                            console.error("Error creating Coordinate Navigation window:", component.errorString())
+                        }
+                    } else {
+                        console.error("Component not ready:", component.errorString())
+                    }
+                }
+            }
+
+            // Go Home Landing Menu item
+            Button {
+                width: parent.width
+                height: 30
+                text: "Go Home Landing"
+
+                background: Rectangle {
+                    // Background color logic
+                    color: parent.pressed ? GcsStyle.PanelStyle.buttonPressedColor :
+                           parent.hovered ? GcsStyle.PanelStyle.buttonHoverColor :
+                           "transparent"
+                    radius: 2
+                }
+
+                // Text styling
+                contentItem: Text {
+                    text: parent.text
+                    color: GcsStyle.PanelStyle.textPrimaryColor
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 11
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                }
+
+                onClicked: {
+                    commandMenu.close()
+                    var component = Qt.createComponent("goHomeLandingWindow.qml")
+                    if (component.status === Component.Ready) {
+                        var window = component.createObject(null)
+                        if (window !== null) {
+                            window.show()
+                        } else {
+                            console.error("Error creating Go Home Landing window:", component.errorString())
+                        }
+                    } else {
+                        console.error("Component not ready:", component.errorString())
+                    }
+                }
+            }
+
+            // Delete All Drones Menu item
+            Button {
+                width: parent.width
+                height: 30
+                text: "Delete All Drones"
+
+                background: Rectangle {
+                    // Background color logic
+                    color: parent.pressed ? "#ff6b6b" :
+                           parent.hovered ? "#ff8e8e" :
+                           "transparent"
+                    radius: 2
+                }
+
+                // Text styling
+                contentItem: Text {
+                    text: parent.text
+                    color: parent.pressed || parent.hovered ? "#ffffff" : "#ff4444"
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 11
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                }
+
+                onClicked: {
+                    commandMenu.close()
+                    deleteAllDronesWindow.open()
+                }
+            }
+        }
+    }
+
+    // Creates pop-up for Delete drone command
+    Popup {
+        id: deleteAllDronesWindow
+        modal: true
+        focus: true
+        width: 200
+        height: 200
+        x: 105
+        y: menuBar.height + 5
+
+        background: Rectangle {
+            color: "#f8d7da"
+            border.color: "#f5c6cb"
+            radius: 10
+        }
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: 20
+            spacing: 10
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+
+            Text {
+                text: "Are you sure you want to delete ALL drones?"
+                wrapMode: Text.WordWrap
+                width: parent.width - 20
+                horizontalAlignment: Text.AlignHCenter
+                font.pointSize: 12
+                color: GcsStyle.PanelStyle.textPrimaryColor
+            }
+
+            Button {
+                text: "No"
+                width: parent.width
+                onClicked: {
+                    deleteAllDronesWindow.close()
+                }
+            }
+
+            Button {
+                text: "Yes"
+                width: parent.width
+                onClicked: {
+                    droneController.deleteALlDrones_UI()
+                    deleteAllDronesWindow.close()
+                    confirmWindow.open()
+                }
+            }
+        }
+    }
+
+    Popup {
+        id: confirmWindow
+        modal: true
+        focus: true
+        width: 200
+        height: 200
+        x: 105
+        y: menuBar.height + 5
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: 20
+            spacing: 10
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+
+            Text {
+                text: "Drone successfully deleted!"
+                color: GcsStyle.PanelStyle.textPrimaryColor
+            }
+
+            Button {
+                text: "Ok"
+                width: parent.width
+                onClicked: {
+                    confirmWindow.close();
+                }
+            }
+        }
+    }
+}

--- a/DroneStatusPanel.qml
+++ b/DroneStatusPanel.qml
@@ -116,27 +116,22 @@ Rectangle {
         }
     }
 
-    Connections {
-        target: droneTrackingPanel
-        onUpdateSelectedDroneSignal: populateActiveDroneModel(name, status, battery, latitude, longitude, altitude, airspeed)
-    }
 
-    // In this future this would be updated by a pointer: (drone1 -> activeDrone)
-    function populateActiveDroneModel(name, status, battery, latitude, longitude, altitude, airspeed) {
-        if (activeDroneModel.count > 0 && activeDroneModel.get(0).name === name) {
-            // If the same drone is clicked again, toggle visibility
-            mainPanel.visible = !mainPanel.visible;
-        } else {
-            // Update model and ensure the panel is visible
-            activeDroneModel.clear();
-            activeDroneModel.append({name: name,
-                                        status: status,
-                                        battery: battery,
-                                        latitude: latitude,
-                                        longitude: longitude,
-                                        altitude: altitude,
-                                        airspeed: airspeed            });
-            mainPanel.visible = true;
-        }
+    property var activeDrone: null
+
+    function populateActiveDroneModel(drone) {
+        if (!drone) return;
+
+        activeDrone = drone; // store reference to currently active drone
+
+        // Update model
+        activeDroneModel.clear();
+        activeDroneModel.append({name: drone.name,
+                                    status: drone.status,
+                                    battery: drone.battery,
+                                    latitude: drone.latitude,
+                                    longitude: drone.longitude,
+                                    altitude: drone.altitude,
+                                    airspeed: drone.airspeed            });
     }
 }

--- a/DroneTrackingPanel.qml
+++ b/DroneTrackingPanel.qml
@@ -17,7 +17,7 @@ Rectangle {
     color: GcsStyle.PanelStyle.primaryColor
     radius: GcsStyle.PanelStyle.cornerRadius
 
-    signal updateSelectedDroneSignal(string name, string status, string battery, string latitude, string longitude, string altitude, string airspeed)
+    signal droneClicked(var drone)
 
     // Storing the full list of drones allows filtering
     property var fullDroneList: []
@@ -202,9 +202,8 @@ Rectangle {
                         id: droneItem
                         anchors.fill: parent
                         onClicked: {
-                            // ideally this would capture the clicked drone as an OBJECT, not individual properties
-                            // passActiveDrone(model.name, model.status, model.battery)
-                            updateSelectedDroneSignal(model.name, model.status, model.battery, model.latitude, model.longitude, model.altitude, model.airspeed)
+                            var droneObj = model
+                                droneClicked(droneObj)
                         }
                     }
 

--- a/QtMap.qrc
+++ b/QtMap.qrc
@@ -6,6 +6,7 @@
         <file>MapDisplayTypeButton.qml</file>
         <file>DroneTrackingPanel.qml</file>
         <file>DroneStatusPanel.qml</file>
+        <file>DroneMenuBar.qml</file>
         <file>manageDroneWindow.qml</file>
         <file>armWindow.qml</file>
         <file>coordinateNavigationWindow.qml</file>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# The Ground Control Station for Fire-Detection and Suppression
+This is a student-run project from California State Polytechnic University, Pomona. 
+Supervised by [Dr. Subodh Bhandari](https://www.linkedin.com/in/subodh-bhandari-153b6414/), in collaboration with [Lockheed Martin](https://lockheedmartin.com/)
+
+## The mission 
+Building a GCS that enables: 
+- autonomous control of UAV fleets,
+- real-time fire detection and mapping,
+- monitoring and coordination of UAVs for fire suppression,
+- a **UAV-agnostic platform** that can be deployed across our campus and beyond.
+
+### Our working MVP
+"We want to be able to hand this off to another drone team. they’re able to connect their drones (simply inputting the information from their XBees). They fly the drones by setting waypoints on the GCS and are able to see the drones on the map. They’re able to see the drone telemetry. They’re able to send commands for returning home and taking off. This software will be more fun to use than what’s out there."
+
+## The application
+We are building the GCS using the Qt Framework, chosen for its:
+- Cross-platform support (Windows, Linux, macOS)
+- Integration with QML for responsive UI design
+- Signal/slot mechanism for UAV telemetry as well as cross UI functionality 
+- Ability to interface with Python processes (e.g., for XBee communication)
+
+## The GCS Leads
+- Megan Bee, Co-Lead
+- Carlos Vargas, Co-Lead
+- Ryan Vu, Senior Developer
+- Danny Caceres, Senior Developer

--- a/dronecontroller.h
+++ b/dronecontroller.h
@@ -39,11 +39,17 @@ public:
     void startXbeeMonitoring();
     Q_INVOKABLE QVariantList getDrones() const;
     Q_INVOKABLE bool isSimulationMode() const;
+    Q_INVOKABLE DroneClass* getDrone(int index) const;
 
 public slots:
-    void saveDrone(const QString &name, const QString &role, const QString &xbeeId, const QString &xbeeAddress);
-    void updateDrone(const QString &oldXbeeId, const QString &name, const QString &role, const QString &xbeeId, const QString &xbeeAddress);
-    void deleteDrone(const QString &xbeeId);
+    void saveDrone(const QSharedPointer<DroneClass> &drone);
+    void createDrone(const QString &name,
+                                 const QString &role,
+                                 const QString &xbeeId,
+                                 const QString &xbeeAddress
+                     );
+    void updateDrone(const QSharedPointer<DroneClass> &drone);
+    void deleteDrone(const QString &xbeeid);
     void deleteALlDrones_UI();
 
 // Declaration for retrieving the drone list
@@ -57,9 +63,9 @@ private slots:
     void tryConnectToDataFile();
 
 signals:
-    void droneAdded();
-    void droneUpdated();
-    void droneDeleted();
+    void droneAdded(const QSharedPointer<DroneClass> &drone);
+    void droneUpdated(const QSharedPointer<DroneClass> &drone);
+    void droneDeleted(const QSharedPointer<DroneClass> &drone);
     void droneStateChanged(const QString &droneName);
     void xbeeConnectionChanged(bool connected);
     void dronesChanged();

--- a/main.cpp
+++ b/main.cpp
@@ -127,6 +127,11 @@ int main(int argc, char *argv[])
     // Register the FileHandler class so that it can be used in QML
     qmlRegisterType<FileHandler>("com.gcs.filehandler", 1, 0, "FileHandler");
 
+    // Register droneclass to QML
+    qmlRegisterUncreatableType<DroneClass>(
+        "com.gcs.dronecontroller", 1, 0, "DroneClass",
+        "DroneClass cannot be created from QML");
+
     // Expose dronecontroller to QML
     qmlRegisterType<DroneController>("com.gcs.dronecontroller", 1, 0, "DroneController");
     DroneController droneController(gcs_db_manager);

--- a/main.qml
+++ b/main.qml
@@ -58,6 +58,19 @@ Window {
             left: parent.left
             margins: 10
         }
+        onDroneClicked: {
+                console.log("Clicked drone:", drone.name)
+                if (droneStatusPanel.activeDrone && droneStatusPanel.activeDrone.name === drone.name) {
+                    // Toggle the visability of the status panel if same drone is clicked
+                    droneStatusPanel.visible = !droneStatusPanel.visible
+                } else {
+                    // update status panel with new info
+                    droneStatusPanel.populateActiveDroneModel(drone)
+
+                    // Ensure panel is visible for a new drone
+                    droneStatusPanel.visible = true
+                }
+            }
     }
 
     /*
@@ -99,15 +112,7 @@ Window {
                 for (var i = 0; i < drones.length; i++) {
                     if (drones[i].name === droneName) {
                         // Update the status panel
-                        droneTrackingPanel.updateSelectedDroneSignal(
-                            drones[i].name,
-                            drones[i].status,
-                            drones[i].battery,
-                            drones[i].latitude,
-                            drones[i].longitude,
-                            drones[i].altitude,
-                            drones[i].airspeed
-                        );
+                        droneStatusPanel.populateActiveDroneModel(drones[i]);
                         break;
                     }
                 }

--- a/main.qml
+++ b/main.qml
@@ -17,204 +17,6 @@ Window {
     visible: true
     title: qsTr("GCS - Cal Poly Pomona")
 
-    // Menu bar for the top of the application to display various features and actions
-    MenuBar {
-        id: menuBar
-
-        // GCS Menu with two items:
-        // 1. "Manage Drones" that opens the manage drone window.
-        // 2. "Command Menu" that shows a submenu with the 4 command options.
-        Menu {
-            id: gcsMenu
-            title: qsTr("GCS")
-            // first button tab of the menu bar allows you to open the manage drone panel
-            // this button is attached to the manageDroneWindow.qml
-
-            // "Manage Drones" menu item
-            MenuItem {
-                text: qsTr("Manage Drones")
-                onTriggered: {
-                    var component = Qt.createComponent("manageDroneWindow.qml")
-                    if (component.status === Component.Ready) {
-                        var window = component.createObject(null)
-                        if (window !== null) {
-                            window.show()
-                        } else {
-                            console.error("Error creating object:", component.errorString());
-                        }
-                    } else {
-                        console.error("Component not ready:", component.errorString());
-                    }
-                }
-            }
-        }
-
-        Menu {
-            id: commandMenu
-            title: qsTr("Command Menu")
-
-            MenuItem {
-                id: armMenuItem
-                text: qsTr("ARM")
-                onTriggered: {
-                    // Load and show armWindow.qml
-                    var component = Qt.createComponent("armWindow.qml")
-                    if (component.status === Component.Ready) {
-                        var window = component.createObject(null)
-                        if (window !== null) {
-                            window.show()
-                        } else {
-                            console.error("Error creating ARM window:", component.errorString())
-                        }
-                    } else {
-                        console.error("Component not ready:", component.errorString())
-                    }
-                }
-            }
-            MenuItem {
-                id: takeOffMenuItem
-                text: qsTr("Take-off")
-                onTriggered: {
-                    // Load and show takeOffWindow.qml
-                    var component = Qt.createComponent("takeOffWindow.qml")
-                    if (component.status === Component.Ready) {
-                        var window = component.createObject(null)
-                        if (window !== null) {
-                            window.show()
-                        } else {
-                            console.error("Error creating Take-off window:", component.errorString())
-                        }
-                    } else {
-                        console.error("Component not ready:", component.errorString())
-                    }
-                }
-            }
-            MenuItem {
-                id: coordinateNavMenuItem
-                text: qsTr("Coordinate Navigation")
-                onTriggered: {
-                    // Load and show coordinateNavigationWindow.qml
-                    var component = Qt.createComponent("coordinateNavigationWindow.qml")
-                    if (component.status === Component.Ready) {
-                        var window = component.createObject(null)
-                        if (window !== null) {
-                            window.show()
-                        } else {
-                            console.error("Error creating Coordinate Navigation window:", component.errorString())
-                        }
-                    } else {
-                        console.error("Component not ready:", component.errorString())
-                    }
-                }
-            }
-            MenuItem {
-                id: goHomeLandingMenuItem
-                text: qsTr("Go Home Landing")
-                onTriggered: {
-                    // Load and show goHomeLandingWindow.qml
-                    var component = Qt.createComponent("goHomeLandingWindow.qml")
-                    if (component.status === Component.Ready) {
-                        var window = component.createObject(null)
-                        if (window !== null) {
-                            window.show()
-                        } else {
-                            console.error("Error creating Go Home Landing window:", component.errorString())
-                        }
-                    } else {
-                        console.error("Component not ready:", component.errorString())
-                    }
-                }
-            }
-
-            MenuItem {
-                text: qsTr("Delete All Drones")
-                onTriggered: {
-                    deleteAllDronesWindow.open();
-                }
-            }
-        }
-    }
-
-    // Creates pop-up for Delete drone command
-    Popup {
-            id: deleteAllDronesWindow
-            modal: true
-            focus: true
-            width: 200
-            height: 200
-
-            Column {
-                anchors.fill: parent
-                anchors.margins: 20
-                spacing: 10
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-
-                // Display confirmation message
-                Text {
-                    id: confirmMessage
-                    text: "Are you sure you want to delete ALL drones?"
-                    wrapMode: Text.WordWrap
-                    // Width is parent's width minus margins
-                    width: parent.width - 20
-                    horizontalAlignment: Text.AlignHCenter
-                    font.pointSize: 12
-                    color: GcsStyle.PanelStyle.textPrimaryColor
-                }
-
-                Button {
-                    text: "No"
-                    width: parent.width
-                    onClicked: {
-                        deleteAllDronesWindow.close()
-                    }
-                }
-
-                Button {
-                    text: "Yes"
-                    width: parent.width
-                    onClicked: {
-                        droneController.deleteALlDrones_UI()
-                        deleteAllDronesWindow.close()
-                        confirmWindow.open()
-                    }
-                }
-            }
-        }
-           /* Display input fields for drone object
-            Current: Drone Name, Status, Battery @ Connor
-            New: Drone Name, Drone Type*, Xbee ID, Type @ Brandon
-            Drone ID will seen somewhere else
-          */
-
-        Popup {
-            id: confirmWindow
-            modal: true
-            focus: true
-            width: 200
-            height: 200
-            Column {
-                anchors.fill: parent
-                anchors.margins: 20
-                spacing: 10
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-                Text {
-                    id: confirmWindowText
-                    text: "Drone successfully deleted!"
-                    color: GcsStyle.PanelStyle.textPrimaryColor
-                }
-
-                Button {
-                    text: "Ok"
-                    width: parent.width
-                    onClicked: {
-                        confirmWindow.close();
-                    }
-                }
-            }
-        }
-
     // These are our components that sit on top of our Window object
     QmlMap {
         // Reference by id not file name
@@ -239,10 +41,20 @@ Window {
         }
         visible: false
     }
+    // Menu bar above the drone tracking panel
+    DroneMenuBar {
+        id: menuBar
+        anchors {
+            top: parent.top
+            left: parent.left
+            margins: 10
+        }
+    }
+
     DroneTrackingPanel {
         id: droneTrackingPanel
         anchors {
-            top: parent.top
+            top: menuBar.bottom
             left: parent.left
             margins: 10
         }

--- a/manageDroneWindow.qml
+++ b/manageDroneWindow.qml
@@ -226,7 +226,7 @@ Window {
 
             // Optionally save to database
             try {
-                droneController.saveDrone(
+                droneController.createDrone(
                     drone.name,
                     drone.role,
                     drone.xbeeId,
@@ -600,7 +600,7 @@ Window {
                             try {
                                 // We no longer manually add to the model
                                 // Instead, we rely on the dronesChanged signal to update the UI
-                                droneController.saveDrone(
+                                droneController.createDrone(
                                     droneNameField.text,
                                     droneRole.text,
                                     droneXbeeID.text,
@@ -655,14 +655,21 @@ Window {
 
                     onClicked: {
                         if (selectedDroneIndex >= 0 && droneNameField.text.length > 0) {
-                            var oldXbeeAddress = droneModel.get(selectedDroneIndex).xbeeAddress;
+                            // get the actual DroneClass from the model
+                            var droneObj = droneModel.get(selectedDroneIndex);
 
                             // Update the item in the model
-                                try {
-                                    droneController.updateDrone(oldXbeeAddress, droneNameField.text,
-                                                             droneRole.text, droneXbeeID.text, droneXbeeAddr.text);
-                                    // Update model from database
-                                    syncModelWithDatabase();
+                            droneObj.name = droneNameField.text;
+                            droneObj.role = droneRole.text;
+                            droneObj.xbeeID = droneXbeeID.text;
+                            droneObj.xbeeAddress = droneXbeeAddr.text;
+                            // Update the item in the model
+                            try {
+                                // Pass the whole object to C++
+                                droneController.updateDrone(droneObj);
+
+                                // Update model from database
+                                syncModelWithDatabase();
                                 successMessage.text = "Drone updated successfully!";
                                 successPopup.open();
                                 clearFields();

--- a/panelStyle.qml
+++ b/panelStyle.qml
@@ -29,6 +29,9 @@ QtObject {
     readonly property int buttonRadius: 8
     readonly property color buttonColor: "transparent"
     readonly property color buttonActiveColor: "#4B88A2"
+    readonly property color buttonHoverColor: "#e6f0ff"
+    readonly property color buttonPressedColor: "#cfe0ff"
+    readonly property color buttonBorderColor: "#c8c8c8"
 
     // List view properties
     readonly property color listItemEvenColor: secondaryColor


### PR DESCRIPTION
## Summary

- Moved the menu bar from the window border to inside the application UI at the top of the drone tracking panel for better user experience and integration.

## Implementation Details

### Created separate component ‘DroneMenuBar.qml’

- Removed old MenuBar from window border in main.qml
- Created DroneMenuBar.qml component for better structure.
- Component structure
├── Row (Button Container)
│   ├── GCS Button → gcsMenu Popup
│   └── Command Button → commandMenu Popup
├── deleteAllDronesWindow Popup
└── confirmWindow Popup

### Switched from MenuItem + Popup to Button/Rectangle + Popup

- Why?: MenuItem had limited styling and couldn’t be positioned inside the UI
- Qt’s Button component allows full control over appearance and position, and the menu bar now matches existing panel design
- Copied existing onTriggered logic directly to onClicked handlers for opening windows, closing popups, and error handling.

### **Custom Rectangle + MouseArea for Rounded Hover Effects**

- Initial Approach: Attempted to use Button with custom background Rectangle for rounded corners but Button’s built-in hovered/pressed properties don’t work well with custom roudned background
- Solution: Replaced button with custom Rectangle and MouseArea implementation which has precise control over hover/click detection in the rounded area.

### Added Keyboard Shortcut to access Command Menu

- Ctrl + Shift + P on Windows
- Command + Shift + P on Mac
- ESC to close menu

### Added universal button properties in panelStyle.qml

- buttonHoverColor: "#e6f0ff"
- buttonPressedColor: "#cfe0ff"
- buttonBorderColor: "#c8c8c8"

### Pictures/Videos
[GCS Task - Menu Bar In GUI.zip](https://github.com/user-attachments/files/22231233/GCS.Task.-.Menu.Bar.In.GUI.zip)
