### PR TITLE
small tweaks to the menu bar icons

### DIFF
--- a/DroneMenuBar.qml
+++ b/DroneMenuBar.qml
@@ -19,7 +19,7 @@ import "qrc:/gcsStyle" as GcsStyle
 //          Maybe not that simple, but the idea is that we don't have to hard
 //          code each command into this file. Because each command does a similar 
 //          thing, we just need to iterate through that list of commands and display them.
-
+ 
 Rectangle {
     id: menuBar
     height: 30 // This height of the entire menu bar controls the height of 
@@ -31,6 +31,8 @@ Rectangle {
     property color hoverClr: GcsStyle.PanelStyle.buttonHoverColor
     property color pressedClr: GcsStyle.PanelStyle.buttonPressedColor
     radius: GcsStyle.PanelStyle.cornerRadius - 3
+        // This radius of the ENTIRE menu bar controls the radius of 
+        // all the menu bar buttons
 
     Row {
         anchors.left: parent.left

--- a/DroneMenuBar.qml
+++ b/DroneMenuBar.qml
@@ -32,7 +32,7 @@ Rectangle {
             id: gcsMenuButton
             height: 35
             width: 90
-            radius: 15 // Gives rounded edges
+            radius: GcsStyle.PanelStyle.cornerRadius
             // Button color state logic for hovering/pressing
             color: pressed ? pressedClr :
                    hovered ? hoverClr :
@@ -68,15 +68,15 @@ Rectangle {
             }
 
             // Shadow effect
-            Rectangle {
-                x: gcsMenuButton.x + 2
-                y: gcsMenuButton.y + 2
-                width: gcsMenuButton.width
-                height: gcsMenuButton.height
-                color: "#30000000"
-                radius: gcsMenuButton.radius
-                z: -1
-            }
+            // Rectangle {
+            //     x: gcsMenuButton.x + 2
+            //     y: gcsMenuButton.y + 2
+            //     width: gcsMenuButton.width
+            //     height: gcsMenuButton.height
+            //     color: "#30000000"
+            //     radius: parent.radius
+            //     z: -1
+            // }
         }
 
         // Command Menu Button
@@ -84,7 +84,7 @@ Rectangle {
             id: commandMenuButton
             height: 35
             width: 135
-            radius: 15 // Gives rounded edges
+            radius: GcsStyle.PanelStyle.cornerRadius
             // Button color state logic for hovering/pressing
             color: pressed ? pressedClr :
                    hovered ? hoverClr :
@@ -120,16 +120,16 @@ Rectangle {
             }
 
             // Shadow effect
-            Rectangle {
-                anchors.fill: parent
-                anchors.leftMargin: 2
-                anchors.topMargin: 2
-                anchors.rightMargin: -2
-                anchors.bottomMargin: -2
-                color: "#30000000"
-                radius: parent.radius
-                z: -1
-            }
+            // Rectangle {
+            //     anchors.fill: parent
+            //     anchors.leftMargin: 2
+            //     anchors.topMargin: 2
+            //     anchors.rightMargin: -2
+            //     anchors.bottomMargin: -2
+            //     color: "#30000000"
+            //     radius: parent.radius
+            //     z: -1
+            // }
         }
     }
 

--- a/DroneMenuBar.qml
+++ b/DroneMenuBar.qml
@@ -11,28 +11,39 @@ import "qrc:/gcsStyle" as GcsStyle
  * 2. "Command Menu" that shows a submenu with the 4 command options.
  */
 
+// TODO:    The sizing and spacing for all the elements should be dynamic: 
+//          Meaning changing the text of a button will change the width as well. 
+
+// TODO:    It's worth a shot looking into making the menus dynamic as a WHOLE.
+//          If we're given a json of --> "Commands": {"Take Off", "Arm Drone"}
+//          Maybe not that simple, but the idea is that we don't have to hard
+//          code each command into this file. Because each command does a similar 
+//          thing, we just need to iterate through that list of commands and display them.
+
 Rectangle {
     id: menuBar
-    height: 40
+    height: 30 // This height of the entire menu bar controls the height of 
+                // all the menu bar buttons. 
     color: "transparent"
     // Colors sourced from theme
     property color baseColor: GcsStyle.PanelStyle.primaryColor
     property color borderClr: GcsStyle.PanelStyle.buttonBorderColor
     property color hoverClr: GcsStyle.PanelStyle.buttonHoverColor
     property color pressedClr: GcsStyle.PanelStyle.buttonPressedColor
+    radius: GcsStyle.PanelStyle.cornerRadius - 3
 
     Row {
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
         anchors.margins: 0
-        spacing: 15
+        spacing: 5
 
         // "GCS" Menu Button 
         Rectangle {
             id: gcsMenuButton
-            height: 35
+            height: parent.parent.height
             width: 90
-            radius: GcsStyle.PanelStyle.cornerRadius
+            radius: parent.parent.radius
             // Button color state logic for hovering/pressing
             color: pressed ? pressedClr :
                    hovered ? hoverClr :
@@ -82,9 +93,9 @@ Rectangle {
         // Command Menu Button
         Rectangle {
             id: commandMenuButton
-            height: 35
+            height: parent.parent.height
             width: 135
-            radius: GcsStyle.PanelStyle.cornerRadius
+            radius: parent.parent.radius
             // Button color state logic for hovering/pressing
             color: pressed ? pressedClr :
                    hovered ? hoverClr :

--- a/main.qml
+++ b/main.qml
@@ -29,7 +29,7 @@ Window {
         anchors {
             top: parent.top
             right: parent.right
-            margins: 10
+            margins: GcsStyle.PanelStyle.applicationBorderMargin
         }
     }
     DroneStatusPanel {
@@ -37,7 +37,7 @@ Window {
         anchors {
             top: parent.top
             right: parent.right
-            margins: 10
+            margins: GcsStyle.PanelStyle.applicationBorderMargin
         }
         visible: false
     }
@@ -47,7 +47,7 @@ Window {
         anchors {
             top: parent.top
             left: parent.left
-            margins: 10
+            margins: GcsStyle.PanelStyle.applicationBorderMargin
         }
     }
 
@@ -56,7 +56,7 @@ Window {
         anchors {
             top: menuBar.bottom
             left: parent.left
-            margins: 10
+            margins: GcsStyle.PanelStyle.applicationBorderMargin
         }
         onDroneClicked: {
                 console.log("Clicked drone:", drone.name)

--- a/panelStyle.qml
+++ b/panelStyle.qml
@@ -40,6 +40,7 @@ QtObject {
 
     // Margin and spacing
     readonly property int defaultMargin: 10
+    readonly property int applicationBorderMargin: 8
     readonly property int defaultSpacing: 10
     readonly property int leftButtonSpacing: 0
     readonly property double iconRightMargin: 7.8


### PR DESCRIPTION
Removed the ~show~ shadow from the menu bar for now till we can better implement it. 
Changed the corner radii so that they use dynamic styling instead of hard coding the radius as 15. 

More hotfixes should be made in order to deal with dynamic sizing of the dropdown menus. 