### PR TITLE
Task/carlos new udp port assign

### DIFF
--- a/DroneController.cpp
+++ b/DroneController.cpp
@@ -318,7 +318,7 @@ void DroneController::createDrone(const QString &input_name,
 void DroneController::createAndAddDroneToUI(const QString &input_name,
                                   const uint8_t &input_sysID,
                                   const uint8_t &input_compID,
-                                  int senderUDPPort,
+                                  const quint16 senderUDPPort,
                                   const QObject *parent)
 {
     qDebug() << "Creating drone";
@@ -607,29 +607,29 @@ DroneClass *DroneController::getDrone(int index) const
 
 
 
-bool DroneController::openUdp(quint16 localPort,
+bool DroneController::openUDP(quint16 localPort,
                               const QString& remoteHost,
                               quint16 remotePort)
 {
     if (!udp_) {
         udp_ = std::make_unique<UDPLink>(this);
-        // Uncomment the following connection to test basic UDP connection
-        // connect(udp_.get(), &UDPLink::bytesReceived,
-        //         this,        &DroneController::onUdpBytesReceived);
-
-        // This connections listens for udp packets from previously unknown udp ports
-        connect(udp_.get(), &UDPLink::newUDPPeer,
-                this,        &DroneController::onNewUDPPeer);
     }
     if (!mavTx_) mavTx_ = std::make_unique<MAVLinkSender>(udp_.get(), this);
     
     if (!mavRx_) {
         mavRx_ = std::make_unique<MAVLinkReceiver>(this);
-        connect(udp_.get(), &UDPLink::bytesReceived,
-                mavRx_.get(), &MAVLinkReceiver::onBytes);
-        connect(mavRx_.get(), &MAVLinkReceiver::messageReceived,
-                this,         &DroneController::onMavlinkMessage);
     }
+    // Keeps sender port out of MAVLinkReceiver — glues it here with a lambda.
+    if (udpMavlinkBytesConn_) {
+        QObject::disconnect(udpMavlinkBytesConn_);
+    }
+    udpMavlinkBytesConn_ = connect(udp_.get(), &UDPLink::bytesReceived, this,
+            [this](const QByteArray& bytes, quint16 senderPort) {
+                if (!mavRx_) { return; }
+                const RxMavlinkMsg m = mavRx_->getMAVLinkFromBytes(bytes);
+                if (m.msgid == 0 && m.payload.isEmpty()) { return; }
+                onMavlinkMessage(m, senderPort);
+            });
 
     const bool ok = udp_->open(localPort, QHostAddress(remoteHost), remotePort);
     if (!ok) {
@@ -652,23 +652,6 @@ void DroneController::onUdpBytesReceived(const QByteArray& bytes)
              << hex;
 }
 
-void DroneController::onNewUDPPeer(const QByteArray& bytes, const int& senderUDPPort) 
-{
-    if (!mavRx_) {
-        qWarning() << "mavRx_ is null; cannot parse MAVLink";
-        return;
-    }
-    RxMavlinkMsg m = mavRx_->getMAVLinkFromBytesWithFreshState(bytes);
-    if (m.msgid == 0 && m.payload.isEmpty()) {
-        // No complete MAVLink message in this packet (e.g. partial or non-MAVLink data)
-        const int preview = qMin(bytes.size(), 20);
-        qDebug() << "No MAVLink message in packet from port" << senderUDPPort
-        << "size=" << bytes.size() << "first bytes (hex):" << bytes.left(preview).toHex(' ');
-        return;
-    }
-    QString name = "My Drone " + QString::number(senderUDPPort);
-    createAndAddDroneToUI(name, m.sysid, m.compid, senderUDPPort, nullptr);
-}
 
 bool DroneController::openUART(const QString& port, int baud)
 {
@@ -678,11 +661,18 @@ bool DroneController::openUART(const QString& port, int baud)
     //  set up receiver & wire signals
     if (!mavRx_) {
         mavRx_ = std::make_unique<MAVLinkReceiver>(this);
-        connect(uartDevice_.get(), &UARTLink::bytesReceived,
-                mavRx_.get(), &MAVLinkReceiver::onBytes);
-        connect(mavRx_.get(), &MAVLinkReceiver::messageReceived,
-                this,        &DroneController::onMavlinkMessage);
     }
+    // Serial has no UDP port; pass 0 (not used for routing on UART).
+    if (uartMavlinkBytesConn_) {
+        QObject::disconnect(uartMavlinkBytesConn_);
+    }
+    uartMavlinkBytesConn_ = connect(uartDevice_.get(), &UARTLink::bytesReceived, this,
+            [this](const QByteArray& bytes) {
+                if (!mavRx_) { return; }
+                const RxMavlinkMsg m = mavRx_->getMAVLinkFromBytes(bytes);
+                if (m.msgid == 0 && m.payload.isEmpty()) { return; }
+                onMavlinkMessage(m, 0);
+            });
 
     const bool ok = uartDevice_->open(port, baud);
     if (!ok) {
@@ -871,12 +861,13 @@ bool DroneController::requestTelem(QSharedPointer<DroneClass> drone) {
 
     const QList<int> requestDataCommands = {
         MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
-        MAVLINK_MSG_ID_SYS_STATUS,
+        // MAVLINK_MSG_ID_SYS_STATUS, // WARNING: They consume quite some bandwidth, so use only for important status and error messages
+        // more on status text: https://mavlink.io/en/messages/common.html#STATUSTEXT
         MAVLINK_MSG_ID_ATTITUDE
     };
 
     if (!mavTx_ || !mavTx_->isLinkOpen()) {
-        qWarning() << "MAVLink sender not ready; call openUdp() (or openUART()) first";
+        qWarning() << "MAVLink sender not ready; call openUDP() (or openUART()) first";
         return false;
     }
 
@@ -906,7 +897,7 @@ QSharedPointer<DroneClass> DroneController::getDroneBySysID(uint8_t sysID)
     return {};
 }
 
-void DroneController::onMavlinkMessage(const RxMavlinkMsg& m)
+void DroneController::onMavlinkMessage(const RxMavlinkMsg& m, quint16 senderUDPPort)
 {
     // Rebuild a mavlink_message_t from the envelope so we can use decode helpers
     mavlink_message_t msg{};
@@ -920,7 +911,8 @@ void DroneController::onMavlinkMessage(const RxMavlinkMsg& m)
 
     auto drone = getDroneBySysID(sysID);
     if (drone.isNull()) {
-        qDebug() << "NULL Drone";
+        QString name = "My Drone " + QString::number(senderUDPPort);
+        createAndAddDroneToUI(name, sysID, compID, senderUDPPort, nullptr);
         return;
     }
 
@@ -1015,7 +1007,7 @@ void DroneController::onMavlinkMessage(const RxMavlinkMsg& m)
         break;
     }
     default:
-        qWarning() << "unexpected message type: " << msg.msgid;
+        qInfo() << "Unexpected MAVLink message type: " << msg.msgid;
         break;
     }
 }

--- a/DroneController.cpp
+++ b/DroneController.cpp
@@ -861,8 +861,7 @@ bool DroneController::requestTelem(QSharedPointer<DroneClass> drone) {
 
     const QList<int> requestDataCommands = {
         MAVLINK_MSG_ID_GLOBAL_POSITION_INT,
-        // MAVLINK_MSG_ID_SYS_STATUS, // WARNING: They consume quite some bandwidth, so use only for important status and error messages
-        // more on status text: https://mavlink.io/en/messages/common.html#STATUSTEXT
+        MAVLINK_MSG_ID_SYS_STATUS, // contains the battery
         MAVLINK_MSG_ID_ATTITUDE
     };
 

--- a/DroneController.cpp
+++ b/DroneController.cpp
@@ -318,7 +318,7 @@ void DroneController::createDrone(const QString &input_name,
 void DroneController::createAndAddDroneToUI(const QString &input_name,
                                   const uint8_t &input_sysID,
                                   const uint8_t &input_compID,
-                                  const quint16 senderUDPPort,
+                                  const uint16_t senderUDPPort,
                                   const QObject *parent)
 {
     qDebug() << "Creating drone";
@@ -607,9 +607,9 @@ DroneClass *DroneController::getDrone(int index) const
 
 
 
-bool DroneController::openUDP(quint16 localPort,
+bool DroneController::openUDP(uint16_t localPort,
                               const QString& remoteHost,
-                              quint16 remotePort)
+                              uint16_t remotePort)
 {
     if (!udp_) {
         udp_ = std::make_unique<UDPLink>(this);
@@ -624,7 +624,7 @@ bool DroneController::openUDP(quint16 localPort,
         QObject::disconnect(udpMavlinkBytesConn_);
     }
     udpMavlinkBytesConn_ = connect(udp_.get(), &UDPLink::bytesReceived, this,
-            [this](const QByteArray& bytes, quint16 senderPort) {
+            [this](const QByteArray& bytes, uint16_t senderPort) {
                 if (!mavRx_) { return; }
                 const RxMavlinkMsg m = mavRx_->getMAVLinkFromBytes(bytes);
                 if (m.msgid == 0 && m.payload.isEmpty()) { return; }
@@ -896,7 +896,7 @@ QSharedPointer<DroneClass> DroneController::getDroneBySysID(uint8_t sysID)
     return {};
 }
 
-void DroneController::onMavlinkMessage(const RxMavlinkMsg& m, quint16 senderUDPPort)
+void DroneController::onMavlinkMessage(const RxMavlinkMsg& m, uint16_t senderUDPPort)
 {
     // Rebuild a mavlink_message_t from the envelope so we can use decode helpers
     mavlink_message_t msg{};

--- a/DroneController.h
+++ b/DroneController.h
@@ -13,6 +13,7 @@
 #include <QTextStream>
 #include <QHash>
 #include <QByteArray>
+#include <QMetaObject>
 #include <cstdint>
 
 #include "DroneClass.h"
@@ -69,9 +70,6 @@ class UDPLink;
 class MAVLinkSender;
 class MAVLinkReceiver;
 
-// Friend function 
-void loadDBDronesAsSimulated(DBManager &db);
-
 class DroneController : public QObject 
 {
     Q_OBJECT
@@ -83,8 +81,51 @@ public:
     ~DroneController();
 
     Q_INVOKABLE QVariantList getDrones() const;
+
+    /**
+     * function openUART()
+     * @brief Initializes and opens a UART connection for MAVLink communication.
+     *
+     * This function sets up the required UART transport and MAVLink components,
+     * including the UARTLink, MAVLinkSender, and MAVLinkReceiver. It also establishes
+     * a signal-slot connection to process incoming serial byte streams and convert
+     * them into MAVLink messages.
+     *
+     * If a previous UART-to-MAVLink connection exists, it is disconnected before
+     * creating a new one to prevent duplicate signal handling.
+     *
+     * @param port The serial port identifier (e.g., "/dev/ttyUSB0", "COM3").
+     * @param baud The baud rate for the UART connection.
+     *
+     * @return true if the UART connection was successfully opened.
+     * @return false if the serial port failed to open.
+     */
     Q_INVOKABLE bool openUART(const QString &port, int baud = 57600);
-    Q_INVOKABLE bool openUdp(quint16 localPort,
+    
+
+    /**
+     * function openUDP()
+     * @brief Initializes and opens a UDP connection for MAVLink communication.
+     *
+     * Incoming UDP data is forwarded to the MAVLinkReceiver for parsing. Valid
+     * MAVLink messages are then passed to onMavlinkMessage() along with the sender's
+     * port information.
+     *
+     * If a previous UDP-to-MAVLink connection exists, it is disconnected before
+     * creating a new one to prevent duplicate signal handling.
+     *
+     * @param localPort   The local UDP port to bind and listen on.
+     * @param remoteHost  The target remote host address (IP or hostname).
+     * @param remotePort  The target remote UDP port for outgoing messages.
+     *
+     * @return true if the UDP connection was successfully opened.
+     * @return false if the UDP socket failed to bind or initialize.
+     *
+     * @note The sender port is captured via a lambda and passed along with parsed
+     *       MAVLink messages, keeping transport-layer details separate from the
+     *       MAVLinkReceiver.
+     */
+    Q_INVOKABLE bool openUDP(quint16 localPort,
                              const QString &remoteHost = QStringLiteral("127.0.0.1"),
                              quint16 remotePort = 14550);
 
@@ -152,6 +193,7 @@ public:
     Q_INVOKABLE bool sendToCoord(const QString droneName, float lat, float lon);
     Q_INVOKABLE bool sendToCoordByUavID(const QString uavID, float lat, float lon);
 
+    
     /**
      * function sendGuidedMode()
      * @brief Sends a MAVLink command to set the target drone to Guided mode.
@@ -214,13 +256,6 @@ public:
     Q_INVOKABLE QVariantList getAllDrones() const;
     QVariantList drones() const { return m_dronesVariant; }
     void rebuildVariant();
-    Q_INVOKABLE void updateWaypoints(const QString &droneName, const QVariantList &wps)
-    {
-        QList<QVariantMap> list;
-        for (const QVariant &v : wps)
-            list.append(v.toMap());
-        droneWaypoints[droneName] = list;
-    }
 
     // unknowndronelist
     QVariantList unknownDrones() const { return m_unknownDronesVariant; }
@@ -258,7 +293,7 @@ public slots:
     void createAndAddDroneToUI(const QString &input_name,
                                const uint8_t &input_sysID,
                                const uint8_t &input_compID,
-                               int senderUDPPort,
+                               const quint16 senderUDPPort,
                                const QObject *parent);
 
 
@@ -267,7 +302,7 @@ public slots:
     void deleteALlDrones_UI();
     
     // Functions for serial / MAVLink connections
-    void onMavlinkMessage(const RxMavlinkMsg& msg);
+    void onMavlinkMessage(const RxMavlinkMsg& msg, quint16 senderUDPPort);
     
 signals:
     void droneAdded(const QSharedPointer<DroneClass> &drone);
@@ -278,28 +313,23 @@ signals:
     void unknownDronesChanged();
 
 private:
-    QHash<QString, QList<QVariantMap>> droneWaypoints; // droneName -> list of waypoints
-
     bool checkHeartBeat = false;
-
     DBManager &dbManager;
-
     std::unique_ptr<UARTLink>    uartDevice_;
     std::unique_ptr<UDPLink>     udp_;
     std::unique_ptr<MAVLinkSender> mavTx_;
     std::unique_ptr<MAVLinkReceiver> mavRx_;
+    QMetaObject::Connection udpMavlinkBytesConn_; // Holds functor-based connects so openUDP can replace wiring without duplicates.
+    QMetaObject::Connection uartMavlinkBytesConn_; // Holds functor-based connects so openUART can replace wiring without duplicates.
     QHash<uint32_t, QSharedPointer<DroneClass>> m_drone_map;
     static QList<QSharedPointer<DroneClass>> droneList;
     static QList<QSharedPointer<UnknownDroneClass>> unknownDroneList;
-
-    friend void loadDBDronesAsSimulated(DBManager &db);
 
     QSharedPointer<DroneClass> getDroneByName(const QString &name);
     QSharedPointer<DroneClass> getDroneByXbeeAddress(const QString &address);
 
     /**
      * function getDroneBySysID()
-     * Find drone for a given system ID.
      * 
      * // TODO: Instead of adding a new drone from the list to the map, this function 
      * should return a null ptr so that the function that called it can CREATE a drone.
@@ -335,31 +365,6 @@ private:
      *       when debug output is enabled.
      */
     void onUdpBytesReceived(const QByteArray& bytes);
-
-
-    /**
-     * function onNewUDPPeer()
-     * @brief Handles data received from a previously unknown UDP peer.
-     *
-     * This function attempts to parse an incoming UDP datagram as a MAVLink
-     * message using a fresh parsing state. It is intended for scenarios where
-     * new peers may appear dynamically and need to be identified based on
-     * incoming traffic.
-     *
-     * - If a valid MAVLink message is detected, creates a new drone entry
-     *   in the UI using:
-     *      - A generated name based on the sender’s UDP port.
-     *      - The parsed system ID (sysid).
-     *      - The parsed component ID (compid).
-     *
-     * @param bytes           Raw UDP datagram payload.
-     * @param senderUDPPort   Source UDP port of the sender.
-     * @note The generated drone name format is "My Drone <port>".
-     * @warning No validation is performed (within this function) to prevent 
-     *          duplicate drone entries if multiple valid packets are 
-     *          received from the same peer.
-     */
-    void onNewUDPPeer(const QByteArray& bytes, const int& senderUDPPort);
 
     // Trying out caching QVariantList for QML property usage
     QVariantList m_dronesVariant; // cached QObject* view for QML

--- a/DroneController.h
+++ b/DroneController.h
@@ -125,9 +125,9 @@ public:
      *       MAVLink messages, keeping transport-layer details separate from the
      *       MAVLinkReceiver.
      */
-    Q_INVOKABLE bool openUDP(quint16 localPort,
+    Q_INVOKABLE bool openUDP(uint16_t localPort,
                              const QString &remoteHost = QStringLiteral("127.0.0.1"),
-                             quint16 remotePort = 14550);
+                             uint16_t remotePort = 14550);
 
     
     /**
@@ -293,7 +293,7 @@ public slots:
     void createAndAddDroneToUI(const QString &input_name,
                                const uint8_t &input_sysID,
                                const uint8_t &input_compID,
-                               const quint16 senderUDPPort,
+                               const uint16_t senderUDPPort,
                                const QObject *parent);
 
 
@@ -302,7 +302,7 @@ public slots:
     void deleteALlDrones_UI();
     
     // Functions for serial / MAVLink connections
-    void onMavlinkMessage(const RxMavlinkMsg& msg, quint16 senderUDPPort);
+    void onMavlinkMessage(const RxMavlinkMsg& msg, uint16_t senderUDPPort);
     
 signals:
     void droneAdded(const QSharedPointer<DroneClass> &drone);

--- a/MAVLinkReceiver.cpp
+++ b/MAVLinkReceiver.cpp
@@ -11,7 +11,7 @@ MAVLinkReceiver::MAVLinkReceiver(QObject* parent)
 
 MAVLinkReceiver::~MAVLinkReceiver() = default;   // ← now Impl is complete
 
-void MAVLinkReceiver::onBytes(const QByteArray& data, quint16 senderPort) {
+void MAVLinkReceiver::onBytes(const QByteArray& data, uint16_t senderPort) {
     RxMavlinkMsg out = getMAVLinkFromBytes(data);
     emit messageReceived(out);
 }

--- a/MAVLinkReceiver.cpp
+++ b/MAVLinkReceiver.cpp
@@ -11,10 +11,15 @@ MAVLinkReceiver::MAVLinkReceiver(QObject* parent)
 
 MAVLinkReceiver::~MAVLinkReceiver() = default;   // ← now Impl is complete
 
-void MAVLinkReceiver::onBytes(const QByteArray& data) {
+void MAVLinkReceiver::onBytes(const QByteArray& data, quint16 senderPort) {
     RxMavlinkMsg out = getMAVLinkFromBytes(data);
     emit messageReceived(out);
 }
+
+// void MAVLinkReceiver::onBytes(const QByteArray& data) {
+//     RxMavlinkMsg out = getMAVLinkFromBytes(data);
+//     emit messageReceived(out);
+// }
 
 RxMavlinkMsg MAVLinkReceiver::getMAVLinkFromBytes(const QByteArray& data) {
     mavlink_message_t msg;

--- a/MAVLinkReceiver.h
+++ b/MAVLinkReceiver.h
@@ -37,7 +37,8 @@ public:
     RxMavlinkMsg getMAVLinkFromBytesWithFreshState(const QByteArray& data);
 
 public slots:
-    void onBytes(const QByteArray& data);
+    void onBytes(const QByteArray& data, quint16 senderPort);
+    // void onBytes(const QByteArray& data);
 
 signals:
     void messageReceived(const RxMavlinkMsg& m);

--- a/MAVLinkReceiver.h
+++ b/MAVLinkReceiver.h
@@ -37,7 +37,7 @@ public:
     RxMavlinkMsg getMAVLinkFromBytesWithFreshState(const QByteArray& data);
 
 public slots:
-    void onBytes(const QByteArray& data, quint16 senderPort);
+    void onBytes(const QByteArray& data, uint16_t senderPort);
     // void onBytes(const QByteArray& data);
 
 signals:

--- a/MAVLinkSender.cpp
+++ b/MAVLinkSender.cpp
@@ -48,7 +48,7 @@ qint64 MAVLinkSender::writeToLink(const QByteArray& bytes, uint8_t targetSysID, 
     if (UARTLink_) return UARTLink_->writeBytes(bytes);
     if (UDPLink_) {
         if (udpPort >= 0)
-            return UDPLink_->writeBytes(bytes, static_cast<quint16>(udpPort));
+            return UDPLink_->writeBytes(bytes, static_cast<uint16_t>(udpPort));
         return UDPLink_->writeBytes(bytes, targetSysID);
     }
     return -1;

--- a/UDPLink.cpp
+++ b/UDPLink.cpp
@@ -40,28 +40,6 @@ bool UDPLink::listen(quint16 port) {
 
 void UDPLink::close() { socket_.close(); }
 
-qint64 UDPLink::writeBytes(const QByteArray& b, uint8_t targetSysID) {
-    int remotePort = _remotePortsMap.value(targetSysID);
-    if (socket_.state() != QAbstractSocket::BoundState) {
-        qWarning() << "WriteBytes: socket not bound, state=" << socket_.state();
-        return -1;
-    }
-    if (!_hasPeer) {
-        qWarning() << "writeBytes: no remote peer discovered yet; dropping" << b.size() << "bytes";
-        return -1;
-    }
-
-    const qint64 n = socket_.writeDatagram(b, _remoteAddress, static_cast<quint16>(remotePort));
-    if (n == -1) {
-        qWarning() << "WriteDatagram failed:" << socket_.errorString()
-                   << "to" << _remoteAddress.toString() << ":" << remotePort;
-        emit linkError(socket_.errorString());
-    } else {
-        qDebug() << "Sent" << n << "bytes to" << _remoteAddress.toString() << ":" << remotePort;
-    }
-    return n;
-}
-
 qint64 UDPLink::writeBytes(const QByteArray& b, quint16 remotePort) {
     if (socket_.state() != QAbstractSocket::BoundState) {
         qWarning() << "WriteBytes(port): socket not bound, state=" << socket_.state();
@@ -69,6 +47,10 @@ qint64 UDPLink::writeBytes(const QByteArray& b, quint16 remotePort) {
     }
     if (!_hasPeer) {
         qWarning() << "WriteBytes(port): no remote peer discovered yet; dropping" << b.size() << "bytes";
+        return -1;
+    }
+    if (_remoteAddress == QHostAddress()) {
+        qWarning() << "WriteBytes(port): no remote address discovered yet; dropping" << b.size() << "bytes";
         return -1;
     }
     const qint64 n = socket_.writeDatagram(b, _remoteAddress, remotePort);
@@ -86,42 +68,13 @@ void UDPLink::onReadyRead() {
     readPendingDatagrams();
 }
 
-bool UDPLink::remotePortExists(int targetPort) {
-    uint8_t foundKey = -1;
-    bool found = false;
-    for (auto it = _remotePortsMap.constBegin(); it != _remotePortsMap.constEnd(); ++it) {
-        if (it.value() == targetPort) {
-            foundKey = it.key();
-            found = true;
-            break;
-        }
-    }
-    
-    return found;
-}
-
 void UDPLink::readPendingDatagrams() {
     while (socket_.hasPendingDatagrams()) {
         QNetworkDatagram datagram = socket_.receiveDatagram();
-        if (!datagram.isValid()) {
-            continue;
-        }
-
+        if (!datagram.isValid()) { continue; }
         const QHostAddress senderAddress = datagram.senderAddress();
-        const quint16 senderPort = datagram.senderPort();
-
-        if (!remotePortExists(senderPort)) {
-            // TODO: This needs to be updated so that the currentID matches the system ID 
-            // of the incoming message. Right now it's just hardcoded to iterate through 
-            _remoteAddress = senderAddress;
-            _remotePortsMap.insert(_currentID, senderPort);
-            qInfo() << "New remote peer added:" << _remoteAddress.toString() << ":" << senderPort << ":" << _currentID;
-            _currentID++;
-            _hasPeer = true;
-            QByteArray payload = datagram.data();
-            emit newUDPPeer(payload, static_cast<int>(senderPort));
-        } else {
-            emit bytesReceived(datagram.data());
-        }
+        if (senderAddress != _remoteAddress) { _remoteAddress = senderAddress; }
+        emit bytesReceived(datagram.data(), datagram.senderPort());
+        _hasPeer = true;
     }
 }

--- a/UDPLink.cpp
+++ b/UDPLink.cpp
@@ -4,9 +4,9 @@ UDPLink::UDPLink(QObject* p) : QObject(p) {
     connect(&socket_, &QUdpSocket::readyRead, this, &UDPLink::onReadyRead);
 }
 
-bool UDPLink::open(quint16 localPort,
+bool UDPLink::open(uint16_t localPort,
                    const QHostAddress& remoteHost,
-                   quint16 remotePort) {
+                   uint16_t remotePort) {
     Q_UNUSED(remoteHost);
     Q_UNUSED(remotePort);
 
@@ -27,7 +27,7 @@ bool UDPLink::open(quint16 localPort,
     return true;
 }
 
-bool UDPLink::listen(quint16 port) {
+bool UDPLink::listen(uint16_t port) {
     if (socket_.state() == QAbstractSocket::BoundState) socket_.close();
     if (!socket_.bind(QHostAddress::AnyIPv4, port)) {
         qWarning() << "Listen bind failed on port" << port << ":" << socket_.errorString();
@@ -40,7 +40,7 @@ bool UDPLink::listen(quint16 port) {
 
 void UDPLink::close() { socket_.close(); }
 
-qint64 UDPLink::writeBytes(const QByteArray& b, quint16 remotePort) {
+qint64 UDPLink::writeBytes(const QByteArray& b, uint16_t remotePort) {
     if (socket_.state() != QAbstractSocket::BoundState) {
         qWarning() << "WriteBytes(port): socket not bound, state=" << socket_.state();
         return -1;

--- a/UDPLink.h
+++ b/UDPLink.h
@@ -75,30 +75,40 @@ public:
      * @warning Only IPv4 is used (AnyIPv4). IPv6 is not supported by this bind call.
      */
     bool   isOpen() const { return socket_.state() == QAbstractSocket::BoundState; }
-    qint64 writeBytes(const QByteArray& bytes, uint8_t targetSysID);
-    /// Send to a specific remote port (for UDP)
+    // Send to a specific remote port
     qint64 writeBytes(const QByteArray& bytes, quint16 remotePort);
 
 private:
-    bool remotePortExists(int remotePort);
 
 signals:
-    void newUDPPeer(QByteArray bytes, int senderPort); // Pass bytes by value so the slot
-                                                    // always receives a valid copy
-                                                    // (no reference lifetime issues).
-    void bytesReceived(const QByteArray& bytes);
+    void bytesReceived(const QByteArray& bytes, quint16 senderPort);
     void linkError(const QString& msg);
 
 private slots:
     void onReadyRead();
 
 private:
+
+    /**
+     * function readPendingDatagrams()
+     * @brief Reads and processes all pending UDP datagrams from the socket.
+     *
+     * This function continuously retrieves incoming UDP datagrams from the internal
+     * socket while data is available. For each valid datagram, it updates the stored
+     * remote peer address (if it has changed), emits the received payload via the
+     * bytesReceived signal, and marks that a peer has been detected.
+     *
+     * @details
+     * - Iterates through all pending datagrams using a loop.
+     * - Discards invalid datagrams.
+     * - Tracks the most recent sender address as the active remote peer.
+     * - Emits the raw datagram payload along with the sender's port.
+     * - Sets the internal _hasPeer flag to true once at least one datagram is received.
+     */
     void readPendingDatagrams();
 
     QUdpSocket  socket_;
-    QHostAddress _remoteAddress; // The remote address (127.0.0.1 for example) will be the same for 
-                                 // all incoming connections 
-    QMap<uint8_t, int> _remotePortsMap; 
-    int _currentID = 1; // temporary variable representing the system ID 
+    QHostAddress _remoteAddress; // The remote address (127.0.0.1 for example) will
+                                 // be the same for all incoming connections 
     bool         _hasPeer{false};
 };

--- a/UDPLink.h
+++ b/UDPLink.h
@@ -35,12 +35,12 @@ public:
      *
      * @warning Only IPv4 is used (AnyIPv4). IPv6 is not supported by this bind call.
      */
-    bool   open(quint16 localPort,
+    bool   open(uint16_t localPort,
                 const QHostAddress& remoteHost = QHostAddress::LocalHost,
-                quint16 remotePort = 14550);
+                uint16_t remotePort = 14550);
 
     /// Bind to @p port and receive any UDP datagrams sent to it (from any host). Use for listen-only.
-    bool   listen(quint16 port);
+    bool   listen(uint16_t port);
 
     void   close();
 
@@ -76,12 +76,12 @@ public:
      */
     bool   isOpen() const { return socket_.state() == QAbstractSocket::BoundState; }
     // Send to a specific remote port
-    qint64 writeBytes(const QByteArray& bytes, quint16 remotePort);
+    qint64 writeBytes(const QByteArray& bytes, uint16_t remotePort);
 
 private:
 
 signals:
-    void bytesReceived(const QByteArray& bytes, quint16 senderPort);
+    void bytesReceived(const QByteArray& bytes, uint16_t senderPort);
     void linkError(const QString& msg);
 
 private slots:

--- a/backend/dbmanager.cpp
+++ b/backend/dbmanager.cpp
@@ -17,10 +17,10 @@ DBManager::DBManager(QObject *parent) : QObject(parent) {
     gcs_db_connection.setDatabaseName(dbPath);
 
     if (!gcs_db_connection.open()) {
-        qCritical() << "[dbmanager.cpp] Database connection failed:" << gcs_db_connection.lastError().text();
+        qCritical() << "Database connection failed:" << gcs_db_connection.lastError().text();
         // this is lowkey impossible
     } else {
-        qDebug() << "[dbmanager.cpp] Database connected at:" << dbPath;
+        qDebug() << "Database connected at:" << dbPath;
     }
 }
 
@@ -30,7 +30,7 @@ DBManager::DBManager(QObject *parent) : QObject(parent) {
 DBManager::~DBManager() {
     if (gcs_db_connection.isOpen()) {
         gcs_db_connection.close();
-        qDebug() << "[dbmanager.cpp] Database connection closed.";
+        qDebug() << "Database connection closed.";
     }
 }
 
@@ -39,15 +39,15 @@ DBManager::~DBManager() {
 // Initialize Database (Check if DB exists, create if not)
 void DBManager::initDB() {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open!";
+        qCritical() << "Database is not open!";
     }
 
     if (!createDroneTable()) {
-        qCritical() << "[dbmanager.cpp] Table creation failed!";
+        qCritical() << "Table creation failed!";
     }
 
     if (!createInitialDrones()) {
-        qWarning() << "[dbmanager.cpp] Failed to create initial drones.";
+        qWarning() << "Failed to create initial drones.";
     }
 }
 
@@ -55,7 +55,7 @@ void DBManager::initDB() {
 
 bool DBManager::createDroneTable() {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot create table.";
+        qCritical() << "Database is not open! Cannot create table.";
         return false;
     }
 
@@ -72,11 +72,11 @@ bool DBManager::createDroneTable() {
     )";
 
     if (!query.exec(createTableQuery)) {
-        qCritical() << "[dbmanager.cpp] Failed to create table:" << query.lastError().text();
+        qCritical() << "Failed to create table:" << query.lastError().text();
         return false;
     }
 
-    qDebug() << "[dbmanager.cpp] Drones table created successfully.";
+    qDebug() << "Drones table created successfully.";
     return true;
 }
 
@@ -93,7 +93,7 @@ bool DBManager::createDrone(const QString& droneName, const QString& droneRole,
                             const QString& xbeeID, const QString& xbeeAddress,
                             int* newDroneID) {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot add drone.";
+        qCritical() << "Database is not open! Cannot add drone.";
         return false;
     }
     QSqlQuery checkDupQuery;
@@ -108,13 +108,13 @@ bool DBManager::createDrone(const QString& droneName, const QString& droneRole,
     checkDupQuery.bindValue(":xbeeAddress", xbeeAddress);
 
     if (!checkDupQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Error checking for existing drone:" << checkDupQuery.lastError().text();
+        qCritical() << "Error checking for existing drone:" << checkDupQuery.lastError().text();
         return false;
     }
 
     checkDupQuery.next();
     if (checkDupQuery.value(0).toInt() > 0) {
-        qCritical() << "[dbmanager.cpp] Drone already exists with the same XBee ID or Address.";
+        qCritical() << "Drone already exists with the same XBee ID or Address.";
         return false;
     }
 
@@ -131,17 +131,17 @@ bool DBManager::createDrone(const QString& droneName, const QString& droneRole,
     insertQuery.bindValue(":xbeeAddress", xbeeAddress.isEmpty() ? QVariant(QString()) : xbeeAddress);
 
     if (!insertQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to add drone:" << insertQuery.lastError().text();
+        qCritical() << "Failed to add drone:" << insertQuery.lastError().text();
         return false;
     }
 
     // If the newDroneID pointer is provided, set the last inserted ID
     if (newDroneID != nullptr) {
         *newDroneID = insertQuery.lastInsertId().toInt();
-        qDebug() << "[dbmanager.cpp] New drone ID:" << *newDroneID;
+        qDebug() << "New drone ID:" << *newDroneID;
     }
 
-    qDebug() << "[dbmanager.cpp] Drone added successfully: " << droneName;
+    qDebug() << "Drone added successfully: " << droneName;
     return true;
 }
 
@@ -149,7 +149,7 @@ bool DBManager::createDrone(const QString& droneName, const QString& droneRole,
 
 bool DBManager::deleteDrone(const QString& xbeeIdOrAddress) {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot delete drone.";
+        qCritical() << "Database is not open! Cannot delete drone.";
         return false;
     }
 
@@ -158,11 +158,11 @@ bool DBManager::deleteDrone(const QString& xbeeIdOrAddress) {
     deleteQuery.bindValue(":identifier", xbeeIdOrAddress);
 
     if (!deleteQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to delete the drone: " << deleteQuery.lastError().text();
+        qCritical() << "Failed to delete the drone: " << deleteQuery.lastError().text();
         return false;
     }
 
-    qDebug() << "[dbmanager.cpp] DB: Drone deleted successfully: " << xbeeIdOrAddress;
+    qDebug() << "DB: Drone deleted successfully: " << xbeeIdOrAddress;
     return deleteQuery.numRowsAffected() > 0; // Return true if any rows were affected
 }
 
@@ -170,17 +170,17 @@ bool DBManager::deleteDrone(const QString& xbeeIdOrAddress) {
 
 bool DBManager::deleteAllDrones() {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot delete all drones.";
+        qCritical() << "Database is not open! Cannot delete all drones.";
         return false;
     }
 
     QSqlQuery deleteAllQuery(gcs_db_connection);
     if (!deleteAllQuery.exec("DELETE FROM drones")) {
-        qCritical() << "[dbmanager.cpp] Failed to delete all drones:" << deleteAllQuery.lastError().text();
+        qCritical() << "Failed to delete all drones:" << deleteAllQuery.lastError().text();
         return false;
     }
 
-    qDebug() << "[dbmanager.cpp] All drones deleted successfully.";
+    qDebug() << "All drones deleted successfully.";
     return true;
 }
 
@@ -189,17 +189,17 @@ bool DBManager::deleteAllDrones() {
 bool DBManager::editDrone(int droneID, const QString& droneName, const QString& droneRole,
                           const QString& xbeeID, const QString& xbeeAddress) {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot edit drone.";
+        qCritical() << "Database is not open! Cannot edit drone.";
         return false;
     }
 
     if (droneID <= 0) {
-        qWarning() << "[dbmanager.cpp] Invalid drone ID: " << droneID;
+        qWarning() << "Invalid drone ID: " << droneID;
         return false;
     }
 
     if (!droneName.isEmpty() && checkIfDroneExists(droneName)) {
-        qWarning() << "[dbmanager.cpp] Cannot update drone: name already exists:" << droneName;
+        qWarning() << "Cannot update drone: name already exists:" << droneName;
         return false;
     }
 
@@ -243,11 +243,11 @@ bool DBManager::editDrone(int droneID, const QString& droneName, const QString& 
     }
 
     if (!query.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to edit drone:" << query.lastError().text();
+        qCritical() << "Failed to edit drone:" << query.lastError().text();
         return false;
     }
 
-    qDebug() << "[dbmanager.cpp] Drone updated successfully: ID " << droneID;
+    qDebug() << "Drone updated successfully: ID " << droneID;
     return true;
 }
 
@@ -257,12 +257,12 @@ bool DBManager::editDrone(int droneID, const QString& droneName, const QString& 
 // Shows how to query to fetch all drones, useful for drone list
 void DBManager::printDroneList() {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot fetch drones.";
+        qCritical() << "Database is not open! Cannot fetch drones.";
     }
 
     QSqlQuery query("SELECT drone_id, drone_name, drone_role, xbee_id, xbee_address FROM drones", gcs_db_connection);
 
-    qDebug() << "[dbmanager.cpp] ---- Drone List ----";
+    qDebug() << "---- Drone List ----";
     bool hasData = false;
 
     while (query.next()) {
@@ -273,12 +273,12 @@ void DBManager::printDroneList() {
         QString xbeeId = query.value(3).toString();
         QString xbeeAddress = query.value(4).toString();
 
-        qDebug() << "[dbmanager.cpp] ID:" << id << "| Name:" << name << "| Role:" << role
+        qDebug() << "ID:" << id << "| Name:" << name << "| Role:" << role
                  << "| XBee ID:" << xbeeId << "| XBee Address:" << xbeeAddress;
     }
 
     if (!hasData) {
-        qDebug() << "[dbmanager.cpp] No drones found.";
+        qDebug() << "No drones found.";
     }
 
 }
@@ -287,7 +287,7 @@ void DBManager::printDroneList() {
 
 bool DBManager::checkIfDroneExists(const QString& droneName) {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot check existence.";
+        qCritical() << "Database is not open! Cannot check existence.";
         return false;
     }
 
@@ -296,7 +296,7 @@ bool DBManager::checkIfDroneExists(const QString& droneName) {
     query.bindValue(":droneName", droneName);
 
     if (!query.exec()) {
-        qCritical() << "[dbmanager.cpp] Error checking for existing drone:" << query.lastError().text();
+        qCritical() << "Error checking for existing drone:" << query.lastError().text();
         return false;
     }
 
@@ -309,13 +309,13 @@ bool DBManager::checkIfDroneExists(const QString& droneName) {
 // Lets use this function to have "default" drones. 
 bool DBManager::createInitialDrones() {
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot insert initial drones.";
+        qCritical() << "Database is not open! Cannot insert initial drones.";
         return false;
     }
 
     // Check if drones already exist to avoid duplicates
     if (checkIfDroneExists("Firehawk") || checkIfDroneExists("Octoquad")) {
-        qDebug() << "[dbmanager.cpp] Initial drones not created: table already contains drones.";
+        qDebug() << "Initial drones not created: table already contains drones.";
         return false;
     }
 
@@ -332,10 +332,10 @@ bool DBManager::createInitialDrones() {
     insertQuery.bindValue(":xbeeAddress", "13A20041D365C4");
 
     if (!insertQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to insert Firehawk:" << insertQuery.lastError().text();
+        qCritical() << "Failed to insert Firehawk:" << insertQuery.lastError().text();
         return false;
     } else {
-        qDebug() << "[dbmanager.cpp] Firehawk inserted successfully.";
+        qDebug() << "Firehawk inserted successfully.";
     }
 
 
@@ -346,13 +346,13 @@ bool DBManager::createInitialDrones() {
     insertQuery.bindValue(":xbeeAddress", "0013A200422F2FDF");
 
     if (!insertQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to insert Octoquad:" << insertQuery.lastError().text();
+        qCritical() << "Failed to insert Octoquad:" << insertQuery.lastError().text();
         return false;
     } else {
-        qDebug() << "[dbmanager.cpp] Octoquad inserted successfully.";
+        qDebug() << "Octoquad inserted successfully.";
     }
 
-    qDebug() << "[dbmanager.cpp] Both initial drones created successfully.";
+    qDebug() << "Both initial drones created successfully.";
 
 
     // Insert Third drone
@@ -362,10 +362,10 @@ bool DBManager::createInitialDrones() {
     insertQuery.bindValue(":xbeeAddress", "0013A200422F2FD1");
 
     if (!insertQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to insert Hexacopter:" << insertQuery.lastError().text();
+        qCritical() << "Failed to insert Hexacopter:" << insertQuery.lastError().text();
         return false;
     } else {
-        qDebug() << "[dbmanager.cpp] Hexacopter inserted successfully.";
+        qDebug() << "Hexacopter inserted successfully.";
     }
 
     // Insert fourth drone
@@ -375,10 +375,10 @@ bool DBManager::createInitialDrones() {
     insertQuery.bindValue(":xbeeAddress", "00134200422F2FD1");
 
     if (!insertQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to insert 4:" << insertQuery.lastError().text();
+        qCritical() << "Failed to insert 4:" << insertQuery.lastError().text();
         return false;
     } else {
-        qDebug() << "[dbmanager.cpp] 4 inserted successfully.";
+        qDebug() << "4 inserted successfully.";
     }
 
     // Insert fifth drone
@@ -388,10 +388,10 @@ bool DBManager::createInitialDrones() {
     insertQuery.bindValue(":xbeeAddress", "00134200422F2FD1");
 
     if (!insertQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to insert 5:" << insertQuery.lastError().text();
+        qCritical() << "Failed to insert 5:" << insertQuery.lastError().text();
         return false;
     } else {
-        qDebug() << "[dbmanager.cpp] 5 inserted successfully.";
+        qDebug() << "5 inserted successfully.";
     }
 
     // Insert sixth drone
@@ -401,13 +401,13 @@ bool DBManager::createInitialDrones() {
     insertQuery.bindValue(":xbeeAddress", "00134200422F2FD1");
 
     if (!insertQuery.exec()) {
-        qCritical() << "[dbmanager.cpp] Failed to insert 6:" << insertQuery.lastError().text();
+        qCritical() << "Failed to insert 6:" << insertQuery.lastError().text();
         return false;
     } else {
-        qDebug() << "[dbmanager.cpp] 6 inserted successfully.";
+        qDebug() << "6 inserted successfully.";
     }
 
-    qDebug() << "[dbmanager.cpp] All initial drones created successfully.";
+    qDebug() << "All initial drones created successfully.";
     return true;
 }
 
@@ -419,7 +419,7 @@ bool DBManager::createInitialDrones() {
 QList<QVariantMap> DBManager::fetchAllDrones() {
     QList<QVariantMap> drones;
     if (!gcs_db_connection.isOpen()) {
-        qCritical() << "[dbmanager.cpp] Database is not open! Cannot fetch drones.";
+        qCritical() << "Database is not open! Cannot fetch drones.";
         return drones;
     }
 
@@ -435,7 +435,7 @@ QList<QVariantMap> DBManager::fetchAllDrones() {
             drones.append(drone);
         }
     } else {
-        qCritical() << "[dbmanager.cpp] Failed to fetch drones:" << query.lastError().text();
+        qCritical() << "Failed to fetch drones:" << query.lastError().text();
     }
     return drones;
 }

--- a/main.qml
+++ b/main.qml
@@ -155,7 +155,7 @@ Window {
     }
 
     Component.onCompleted: {
-        droneController.openUdp(14550, "127.0.0.1", 14550)
+        droneController.openUDP(14550, "127.0.0.1", 14550)
         // droneController.openUART("/dev/ttys005", 57600)
         // droneController.openUART("/dev/cu.usbserial-AQ015EBI", 57600)
     }


### PR DESCRIPTION
This removes the UDPLink class's tie with keeping track of UDP ports as well as new connections. Now when a new connection comes in, onMavlinkMessage is responsible for noticing it's a new message based on the fact that the system ID doesn't match existing drones. 

Additionally, the UDP port that sent the mavlink message is passed all the way to the droneclass instance.