### PR TITLE
Added tracking panel quick command buttons with confirmation popups

### DIFF
--- a/DroneTrackingPanel.qml
+++ b/DroneTrackingPanel.qml
@@ -30,7 +30,6 @@ Rectangle {
     property int selectionAnchorIndex: -1 // Anchor index used for Shift-range selections
     property bool multiSelectActive: selectedIndexes.length > 1 
     property string activePanel: "drones"   // "drones", "discovery"
-
     RowLayout {
         anchors.fill: parent
         spacing: 0
@@ -632,8 +631,10 @@ Rectangle {
     // This will let main.qml know the active drone is updated
     onSelectionChanged: function(selected) {
         var idx = selectionAnchorIndex
-        if (idx < 0 || idx >= droneListView.count)
+        if (idx < 0 || idx >= droneListView.count) {
+            activeDroneChanged(null)
             return
+        }
 
         var model = droneListView.model
         var drone = model ? model[idx] : null

--- a/QtMap.qrc
+++ b/QtMap.qrc
@@ -16,6 +16,7 @@
         <file>components/UniversalPopup.qml</file>
         <file>DroneCommandPanel.qml</file>
         <file>settingsWindow.qml</file>
+        <file>TrackingPanelQuickCommands.qml</file>
         <file>components/ToastNotification.qml</file>
     </qresource>
     <qresource prefix="/resources">
@@ -34,6 +35,10 @@
         <file>plusIcon.png</file>
         <file>discoveryPanelIcon.svg</file>
         <file>discoveryPanelIconDarkMode.svg</file>
+        <file>armIcon.svg</file>
+        <file>guidedModeIcon.svg</file>
+        <file>takeoffIcon.svg</file>
+        <file>returnHomeIcon.svg</file>
     </qresource>
     <qresource prefix="/gcsStyle">
         <file>panelStyle.qml</file>

--- a/TrackingPanelQuickCommands.qml
+++ b/TrackingPanelQuickCommands.qml
@@ -1,0 +1,166 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+import "qrc:/gcsStyle" as GcsStyle
+import "./components" as Components
+
+Rectangle {
+    id: root
+
+    property var commandDrone: null // The drone that the user has selected to command
+
+    property string activeAction: "" // The action that the user is currently performing
+
+    width: 70 // Width of the panel
+    height: commandColumn.implicitHeight + 6 // Height of the panel
+    color: GcsStyle.PanelStyle.secondaryColor // Color of the panel
+    radius: GcsStyle.PanelStyle.cornerRadius // Radius of the panel
+    border.color: GcsStyle.PanelStyle.defaultBorderColor // Border color of the panel
+    border.width: GcsStyle.PanelStyle.defaultBorderWidth // Border width of the panel
+
+    ListModel {
+        id: buttonModel
+        ListElement { label: "Arm";     icon: "qrc:/resources/armIcon.svg";         action: "arm" }
+        ListElement { label: "Guided";  icon: "qrc:/resources/guidedModeIcon.svg";  action: "guided" }
+        ListElement { label: "Takeoff"; icon: "qrc:/resources/takeoffIcon.svg";     action: "takeoff" }
+        ListElement { label: "Return";  icon: "qrc:/resources/returnHomeIcon.svg";  action: "return" }
+    }
+
+    // Column layout for the buttons
+    Column {
+        id: commandColumn
+        anchors.centerIn: parent
+
+        // Repeater that iterates over the buttonModel and creates a column for each button
+        Repeater {
+            model: buttonModel 
+            delegate: Column { 
+                width: root.width
+
+                Item {
+                    width: parent.width
+                    height: GcsStyle.PanelStyle.buttonSize + 14
+                    opacity: root.commandDrone !== null ? 1.0 : 0.35
+
+                    property bool hovered: false
+
+                    property bool isActive: root.activeAction === model.action
+
+                    // Hover/active highlight
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width - 10
+                        height: parent.height - 6
+                        radius: 8
+                        color: parent.isActive
+                               ? GcsStyle.PanelStyle.listItemSelectedColor
+                               : parent.hovered
+                                 ? GcsStyle.PanelStyle.listItemHoverColor
+                                 : "transparent"
+                    }
+
+                    // Button icon and label
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        spacing: 2
+
+                        Image {
+                            Layout.alignment: Qt.AlignHCenter
+                            source: model.icon
+                            sourceSize.width: GcsStyle.PanelStyle.iconSize
+                            sourceSize.height: GcsStyle.PanelStyle.iconSize
+                        }
+
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: model.label
+                            color: GcsStyle.PanelStyle.textOnPrimaryColor
+                            font.pixelSize: GcsStyle.PanelStyle.fontSizeXXS
+                            font.family: GcsStyle.PanelStyle.fontFamily
+                        }
+                    }
+
+                    // Hover enabler and click handler for each button
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onEntered: parent.hovered = true
+                        onExited: parent.hovered = false
+                        onClicked: {
+                            if (!root.commandDrone) return
+                            root.activeAction = model.action
+                            switch (model.action) {
+                            case "arm":     armConfirmation.open();     break
+                            case "guided":  guidedConfirmation.open();  break
+                            case "takeoff": takeoffConfirmation.open(); break
+                            case "return":  returnConfirmation.open();  break
+                            }
+                        }
+                    }
+                }
+
+                // Divider line between buttons
+                Rectangle {
+                    width: parent.width * 0.7
+                    height: 1
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    color: GcsStyle.PanelStyle.defaultBorderColor
+                    visible: index < buttonModel.count - 1 // Only show the divider between buttons, not after the last one
+                }
+            }
+        }
+    }
+
+    // Confirmation popups for each action
+    Components.UniversalPopup {
+        id: armConfirmation
+        onClosed: root.activeAction = ""
+        popupTitle: "Arm the UAV?"
+        popupMessage: root.commandDrone && root.commandDrone.name
+                      ? "Are you sure you want to arm " + root.commandDrone.name + "?"
+                      : "No UAV selected"
+        onAccepted: {
+            if (root.commandDrone)
+                droneController.sendArm(root.commandDrone.xbeeAddress, true)
+        }
+    }
+
+    Components.UniversalPopup {
+        id: guidedConfirmation
+        onClosed: root.activeAction = ""
+        popupTitle: "Set UAV to Guided Mode"
+        popupMessage: root.commandDrone && root.commandDrone.name
+                      ? "Are you sure you want to set " + root.commandDrone.name + " to guided mode?"
+                      : "No UAV selected"
+        onAccepted: {
+            if (root.commandDrone)
+                droneController.sendGuidedMode(root.commandDrone.xbeeAddress, true)
+        }
+    }
+
+    Components.UniversalPopup {
+        id: takeoffConfirmation
+        onClosed: root.activeAction = ""
+        popupTitle: "Takeoff"
+        popupMessage: root.commandDrone && root.commandDrone.name
+                      ? "Are you sure you want to takeoff " + root.commandDrone.name + "?"
+                      : "No UAV selected"
+        onAccepted: {
+            if (root.commandDrone)
+                droneController.sendTakeoffCmd(root.commandDrone.xbeeAddress, true)
+        }
+    }
+
+    Components.UniversalPopup {
+        id: returnConfirmation
+        onClosed: root.activeAction = ""
+        popupTitle: "Return Home"
+        popupMessage: root.commandDrone && root.commandDrone.name
+                      ? "Send " + root.commandDrone.name + " back to home location?"
+                      : "No UAV selected"
+        onAccepted: {
+            console.log("[TrackingPanelQuickCommands] Return Home: backend not yet implemented")
+        }
+    }
+}

--- a/TrackingPanelQuickCommands.qml
+++ b/TrackingPanelQuickCommands.qml
@@ -13,7 +13,7 @@ Rectangle {
 
     width: 70 // Width of the panel
     height: commandColumn.implicitHeight + 6 // Height of the panel
-    color: GcsStyle.PanelStyle.secondaryColor // Color of the panel
+    color: GcsStyle.PanelStyle.primaryColor // Color of the panel
     radius: GcsStyle.PanelStyle.cornerRadius // Radius of the panel
     border.color: GcsStyle.PanelStyle.defaultBorderColor // Border color of the panel
     border.width: GcsStyle.PanelStyle.defaultBorderWidth // Border width of the panel

--- a/armIcon.svg
+++ b/armIcon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2v10"/>
+  <path d="M6.343 4.343a8 8 0 1 0 11.314 0"/>
+</svg>

--- a/guidedModeIcon.svg
+++ b/guidedModeIcon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"/>
+  <line x1="12" y1="3" x2="12" y2="6"/>
+  <line x1="12" y1="18" x2="12" y2="21"/>
+  <line x1="3" y1="12" x2="6" y2="12"/>
+  <line x1="18" y1="12" x2="21" y2="12"/>
+  <circle cx="12" cy="12" r="2" fill="white" stroke="white"/>
+</svg>

--- a/main.qml
+++ b/main.qml
@@ -105,6 +105,17 @@ Window {
         }
     }
 
+    TrackingPanelQuickCommands {
+        anchors {
+            top: droneTrackingPanel.top
+            left: droneTrackingPanel.right
+            leftMargin: 8
+        }
+        visible: droneTrackingPanel.activePanel === "drones"
+        commandDrone: mainWindow.activeDrone
+        z: 10
+    }
+
     // Shortcut for toggling follow functionality (cmd + f or ctrl + f)
     Shortcut {
         sequence: StandardKey.Find

--- a/returnHomeIcon.svg
+++ b/returnHomeIcon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"/>
+  <line x1="12" y1="7" x2="12" y2="16"/>
+  <polyline points="8 12 12 16 16 12"/>
+  <line x1="9" y1="16" x2="15" y2="16"/>
+</svg>

--- a/takeoffIcon.svg
+++ b/takeoffIcon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="11" width="16" height="10" rx="2"/>
+  <line x1="12" y1="15" x2="12" y2="3"/>
+  <polyline points="8 7 12 3 16 7"/>
+</svg>


### PR DESCRIPTION
## Summary
- Added a quick-command panel (TrackingPanelQuickCommands.qml) to the right of the Drone Tracking Panel
- Buttons for Arm, Guided Mode, Takeoff, and Return Home - each opens a confirmation popup before sending the command, matching the Command Menu flow
- Panel hides when switching to the Discovery tab, and buttons dim when no drone is selected

## Technical Notes
- Component is placed in main.qml anchored to the right of DroneTrackingPanel, bound to mainWindow.activeDrone (same pattern as DroneCommandPanel)
- No backend changes - uses existing sendArm(), sendGuidedMode(), sendTakeoffCmd() on DroneController
- Added 4 SVG icons registered in `QtMap.qrc` under `/resources`
 
 More Info at https://www.notion.so/Task-Quick-Command-Sidebar-32ada92034d580dfbaa0c61b859b21c4?source=copy_link